### PR TITLE
`addFunc`'s `exported` parameter should not result in an export if a `false` value is provided

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -51,7 +51,7 @@ export class Module {
 
   addFunc = (func: Func<DataType>, exported?: boolean | string) => {
     if (exported) {
-      func.exportName = typeof exported === 'boolean' ? func.name : exported;
+      func.exportName = exported && exported === true ? func.name : exported;
     }
     this.funcs.push(func);
   };


### PR DESCRIPTION
If we call `addFunc('foo', false)`, then the function gets exported anyway.