### PR TITLE
feat: Full integer instruction support

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,5 +1,8 @@
 import { NoInfer } from './utils';
 import {
+  Clz,
+  Ctz,
+  Popcnt,
   Add,
   Block,
   Call,
@@ -19,6 +22,14 @@ import {
   NumericDataType,
   RemSigned,
   RemUnsigned,
+  And,
+  Or,
+  Xor,
+  ShiftLeft,
+  ShiftRightSigned,
+  ShiftRightUnsigned,
+  RotateLeft,
+  RotateRight,
   Store,
   Sub,
   Instr,
@@ -191,6 +202,75 @@ export const global = {
 };
 
 /**
+ * Creates a node for the `clz` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].clz [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const clz = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): Clz<T> => ({
+  __nodeType: 'clz',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `ctz` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].ctz [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const ctz = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): Ctz<T> => ({
+  __nodeType: 'ctz',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `popcnt` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].popcnt [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const popcnt = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): Popcnt<T> => ({
+  __nodeType: 'popcnt',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
  * Creates a node for the `add` instruction.
  *
  * When compiled, results in
@@ -345,6 +425,190 @@ export const remUnsigned = <T extends IntegerDataType>(
   right: Instr<NoInfer<T>>,
 ): RemUnsigned<T> => ({
   __nodeType: 'remUnsigned',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `and` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].and [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const and = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): And<T> => ({
+  __nodeType: 'and',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `or` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].and [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const or = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): Or<T> => ({
+  __nodeType: 'or',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `xor` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].xor [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const xor = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): Xor<T> => ({
+  __nodeType: 'xor',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `shl` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].shl [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const shl = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): ShiftLeft<T> => ({
+  __nodeType: 'shl',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `shr_s` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].shr_s [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const shrSigned = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): ShiftRightSigned<T> => ({
+  __nodeType: 'shrSigned',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `shr_u` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].shr_u [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const shrUnsigned = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): ShiftRightUnsigned<T> => ({
+  __nodeType: 'shrUnsigned',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `rotl` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].rotl [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const rotl = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): RotateLeft<T> => ({
+  __nodeType: 'rotl',
+  dataType,
+  left,
+  right,
+  returnType: dataType,
+});
+
+/**
+ * Creates a node for the `rotr` instruction.
+ *
+ * When compiled, results in
+ * ```wasm
+ * ([dataType].rotr [left] [right])
+ * ```
+ * @param dataType the data type of both operands and of the result type.
+ * @param left the value `Instr` node of the left operand.
+ * @param right the value `Instr` node of the right operand.
+ */
+export const rotr = <T extends IntegerDataType>(
+  dataType: T,
+  left: Instr<NoInfer<T>>,
+  right: Instr<NoInfer<T>>,
+): RotateRight<T> => ({
+  __nodeType: 'rotr',
   dataType,
   left,
   right,

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -65,6 +65,36 @@ export type GlobalTee<T extends NumericDataType = NumericDataType> = {
   returnType: T;
 };
 /**
+ * The node representing the `clz` instruction.
+ */
+export type Clz<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'clz';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `ctz` instruction.
+ */
+export type Ctz<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'ctz';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `popcnt` instruction.
+ */
+export type Popcnt<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'popcnt';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
  * The node representing the `add` instruction.
  */
 export type Add<T extends NumericDataType = NumericDataType> = {
@@ -129,6 +159,86 @@ export type RemSigned<T extends NumericDataType = NumericDataType> = {
  */
 export type RemUnsigned<T extends NumericDataType = NumericDataType> = {
   __nodeType: 'remUnsigned';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `and` instruction.
+ */
+export type And<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'and';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `or` instruction.
+ */
+export type Or<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'or';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `xor` instruction.
+ */
+export type Xor<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'xor';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `shl` instruction.
+ */
+export type ShiftLeft<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'shl';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `shr_s` instruction.
+ */
+export type ShiftRightSigned<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'shrSigned';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `shr_u` instruction.
+ */
+export type ShiftRightUnsigned<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'shrUnsigned';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `rotl` instruction.
+ */
+export type RotateLeft<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'rotl';
+  dataType: T;
+  left: Instr<T>;
+  right: Instr<T>;
+  returnType: T;
+};
+/**
+ * The node representing the `rotr` instruction.
+ */
+export type RotateRight<T extends IntegerDataType = IntegerDataType> = {
+  __nodeType: 'rotr';
   dataType: T;
   left: Instr<T>;
   right: Instr<T>;
@@ -442,6 +552,9 @@ type InstrList =
   | Call
   | CallIndirect
   | Const
+  | Clz
+  | Ctz
+  | Popcnt
   | Add
   | Sub
   | Mul
@@ -449,6 +562,14 @@ type InstrList =
   | DivUnsigned
   | RemSigned
   | RemUnsigned
+  | And
+  | Or
+  | Xor
+  | ShiftLeft
+  | ShiftRightSigned
+  | ShiftRightUnsigned
+  | RotateLeft
+  | RotateRight
   | Load
   | Load8SignExt
   | Load16SignExt
@@ -472,8 +593,8 @@ type InstrList =
 
 type FilterInstrByDataType<I extends { returnType: any }, DT> = I extends any
   ? I['returnType'] & DT extends never
-    ? never
-    : I
+  ? never
+  : I
   : never;
 
 /**

--- a/src/test/__snapshots__/compiler.test.ts.snap
+++ b/src/test/__snapshots__/compiler.test.ts.snap
@@ -22,6 +22,13 @@ exports[`compiler add node 1`] = `
 )"
 `;
 
+exports[`compiler and node 1`] = `
+"(i32.and
+ (i32.const 15790320)
+ (i32.const 986895)
+)"
+`;
+
 exports[`compiler call node 1`] = `
 "(call $abc
  (i32.const 10)
@@ -40,7 +47,21 @@ exports[`compiler call_indirect node 1`] = `
 )"
 `;
 
+exports[`compiler clz node 1`] = `
+"(i32.clz
+ (i32.const 1)
+ (i32.const 2)
+)"
+`;
+
 exports[`compiler const node 1`] = `"(f32.const 1.5)"`;
+
+exports[`compiler ctz node 1`] = `
+"(i32.ctz
+ (i32.const 1)
+ (i32.const 2)
+)"
+`;
 
 exports[`compiler div_s node 1`] = `
 "(i32.div_s
@@ -71,6 +92,20 @@ exports[`compiler mul node 1`] = `
 )"
 `;
 
+exports[`compiler or node 1`] = `
+"(i32.or
+ (i32.const 15790320)
+ (i32.const 986895)
+)"
+`;
+
+exports[`compiler popcnt node 1`] = `
+"(i32.popcnt
+ (i32.const 1)
+ (i32.const 2)
+)"
+`;
+
 exports[`compiler rem_s node 1`] = `
 "(i32.rem_s
  (i32.const 10)
@@ -85,9 +120,51 @@ exports[`compiler rem_u node 1`] = `
 )"
 `;
 
+exports[`compiler rotl node 1`] = `
+"(i32.rotl
+ (i32.const 20)
+ (i32.const 2)
+)"
+`;
+
+exports[`compiler rotr node 1`] = `
+"(i32.rotr
+ (i32.const 20)
+ (i32.const 2)
+)"
+`;
+
+exports[`compiler shl node 1`] = `
+"(i32.shl
+ (i32.const 10)
+ (i32.const 5)
+)"
+`;
+
+exports[`compiler shr_s node 1`] = `
+"(i32.shr_s
+ (i32.const 20)
+ (i32.const 2)
+)"
+`;
+
+exports[`compiler shr_u node 1`] = `
+"(i32.shr_u
+ (i32.const 20)
+ (i32.const 2)
+)"
+`;
+
 exports[`compiler sub node 1`] = `
 "(i32.sub
  (i32.const 10)
  (i32.const 5)
+)"
+`;
+
+exports[`compiler xor node 1`] = `
+"(i32.xor
+ (i32.const 15790320)
+ (i32.const 986895)
 )"
 `;

--- a/src/test/compiler.test.ts
+++ b/src/test/compiler.test.ts
@@ -17,6 +17,30 @@ describe('compiler', () => {
       w.add('i32', w.local.get('i32', 'a'), w.local.get('i32', 'b')),
     );
 
+  test('clz node', () => {
+    expect(
+      compilers.clz(
+        w.clz('i32', w.constant('i32', 1), w.constant('i32', 2)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('ctz node', () => {
+    expect(
+      compilers.ctz(
+        w.ctz('i32', w.constant('i32', 1), w.constant('i32', 2)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('popcnt node', () => {
+    expect(
+      compilers.popcnt(
+        w.popcnt('i32', w.constant('i32', 1), w.constant('i32', 2)),
+      ),
+    ).toMatchSnapshot();
+  });
+  
   test('add function (local.get, i32.add, exported func)', () => {
     const m = new Module();
     m.addFunc(addFunc(), true);
@@ -84,6 +108,70 @@ describe('compiler', () => {
     expect(
       compilers.remUnsigned(
         w.remUnsigned('i32', w.constant('i32', 10), w.constant('i32', 5)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('and node', () => {
+    expect(
+      compilers.and(
+        w.and('i32', w.constant('i32', 0xf0f0f0), w.constant('i32', 0x0f0f0f)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('or node', () => {
+    expect(
+      compilers.or(
+        w.or('i32', w.constant('i32', 0xf0f0f0), w.constant('i32', 0x0f0f0f)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('xor node', () => {
+    expect(
+      compilers.xor(
+        w.xor('i32', w.constant('i32', 0xf0f0f0), w.constant('i32', 0x0f0f0f)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('shl node', () => {
+    expect(
+      compilers.shl(
+        w.shl('i32', w.constant('i32', 10), w.constant('i32', 5)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('shr_s node', () => {
+    expect(
+      compilers.shrSigned(
+        w.shrSigned('i32', w.constant('i32', 20), w.constant('i32', 2)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('shr_u node', () => {
+    expect(
+      compilers.shrUnsigned(
+        w.shrUnsigned('i32', w.constant('i32', 20), w.constant('i32', 2)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('rotr node', () => {
+    expect(
+      compilers.rotr(
+        w.rotr('i32', w.constant('i32', 20), w.constant('i32', 2)),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('rotl node', () => {
+    expect(
+      compilers.rotl(
+        w.rotl('i32', w.constant('i32', 20), w.constant('i32', 2)),
       ),
     ).toMatchSnapshot();
   });


### PR DESCRIPTION
Hey, Jude!
I'm using `wazum` to build the codegen phase to my compiler and wanted to add a few more instructions to complete support for the instructions specified by WebAssembly 2.0 specification along with tests to go along.

I would love to work with `wazum` in the future and perhaps help it reach WebAssembly 2.0 parity. Let me know if you would like that!

Resources:
- Wasm 2.0 instruction reference: https://webassembly.github.io/spec/core/binary/instructions.html